### PR TITLE
[Base Dockerfile] IBMcloud functions(Openwhisk) doesn't start the executable(exec_ow)

### DIFF
--- a/base/Dockerfile-tidyverse
+++ b/base/Dockerfile-tidyverse
@@ -69,8 +69,8 @@ RUN cp openwhisk-runtime-docker/core/actionProxy/owplatform/openwhisk.py /action
 
 #Setup basic executable
 # Copy FaaSr invocation code
-COPY faasr_start_invoke_openwhisk_aws-lambda.R /action/exec_ow
-RUN chmod +x /action/exec_ow
+COPY faasr_start_invoke_openwhisk_aws-lambda.R /action/exec
+RUN chmod +x /action/exec
 
 #Add json schema
 ADD https://raw.githubusercontent.com/FaaSr/FaaSr-package/main/schema/FaaSr.schema.json /action/


### PR DESCRIPTION
[Dockerfile-tidyverse] — line no.72 Edit; /action/exec_ow -> /action/exec
                                       — line no.73 Edit; /action/exec_ow -> /action/exec
**actionproxy.py doesn't read "exec_ow" / it only reads "exec"