### PR TITLE
[faasr_start_invoke] FaaSr library is using itself

### DIFF
--- a/base/faasr_start_invoke_github-actions.R
+++ b/base/faasr_start_invoke_github-actions.R
@@ -1,6 +1,7 @@
 library("httr")
 library("jsonlite")
 library("githubinstall")
+library("FaaSr")
 
 # Recursive function to replace values
 replace_values <- function(user_info, secrets) {

--- a/base/faasr_start_invoke_openwhisk_aws-lambda.R
+++ b/base/faasr_start_invoke_openwhisk_aws-lambda.R
@@ -2,6 +2,7 @@
 
 library("jsonlite")
 library("githubinstall")
+library("FaaSr")
 
 faasr <- commandArgs(TRUE)
 faasr_source <- fromJSON(faasr)


### PR DESCRIPTION
[faasr_start_invoke_github-actions.R] Add library("FaaSr")
[faasr_start_invoke_openwhisk_aws-lambda.R] Add library("FaaSr")
** faasr_start in FaaSr library has library("FaaSr"), and it makes an error.
