### PR TITLE
[support faasr-package changes]

### DIFF
--- a/base/R_packages.R
+++ b/base/R_packages.R
@@ -6,4 +6,3 @@ remotes::install_version('jsonvalidate', version='1.3.2', repos='https://cloud.R
 remotes::install_version('RCurl', version='1.98-1.12', repos='https://cloud.R-project.org')
 remotes::install_version('httr', version='1.4.6', repos='https://cloud.R-project.org')
 remotes::install_version('uuid', version='1.1-0', repos='https://cloud.R-project.org')
-remotes::install_version('githubinstall', version='0.2.2', repos='https://cloud.R-project.org')

--- a/base/faasr_start_invoke_github-actions.R
+++ b/base/faasr_start_invoke_github-actions.R
@@ -150,7 +150,7 @@ gits <- faasr_source$FunctionGitRepo[[funcname]]
 if (length(gits)==0){NULL} else{
   for (path in gits){
     if (endsWith(path, ".git")) {
-      command <- paste("git clone --depth=1",file)
+      command <- paste("git clone --depth=1",path)
       system(command, ignore.stderr=TRUE)
     } else {
       file_name <- basename(path)

--- a/base/faasr_start_invoke_github-actions.R
+++ b/base/faasr_start_invoke_github-actions.R
@@ -164,7 +164,7 @@ if (length(gits)==0){NULL} else{
   }
 }
 	
-packages <- faasr_source$FunctionCRANPackage[[[funcname]]
+packages <- faasr_source$FunctionCRANPackage[[funcname]]
 if (length(packages)==0){NULL} else{
 for (package in packages){
 	install.packages(package)

--- a/base/faasr_start_invoke_github-actions.R
+++ b/base/faasr_start_invoke_github-actions.R
@@ -149,7 +149,6 @@ token <- secrets[["PAYLOAD_GITHUB_TOKEN"]]
 .faasr$FaaSrLog <- Sys.getenv("INPUT_FAASRLOG")
 
 # Replace secrets to faasr
-faasr_source <- .faasr
 faasr_source <- replace_values(.faasr, secrets)
 
 # back to json formate

--- a/base/faasr_start_invoke_github-actions.R
+++ b/base/faasr_start_invoke_github-actions.R
@@ -150,7 +150,7 @@ token <- secrets[["PAYLOAD_GITHUB_TOKEN"]]
 
 # Replace secrets to faasr
 faasr_source <- .faasr
-faasr_source <- replace_values(faasr, secrets)
+faasr_source <- replace_values(.faasr, secrets)
 
 # back to json formate
 .faasr <- toJSON(faasr_source, auto_unbox = TRUE)

--- a/base/faasr_start_invoke_github-actions.R
+++ b/base/faasr_start_invoke_github-actions.R
@@ -147,7 +147,7 @@ gits <- faasr_source$FunctionGitRepo[[funcname]]
 if (length(gits)==0){NULL} else{
   for (path in gits){
     file_name <- basename(path)
-    if (grepl("\\.", file_name)){
+    if (endsWith(file_name, ".R") || endsWith(file_name, ".r")){
       content <- get_github_raw(token, path)
       eval(parse(text=content))
     }else{

--- a/base/faasr_start_invoke_github-actions.R
+++ b/base/faasr_start_invoke_github-actions.R
@@ -37,7 +37,7 @@ replace_values <- function(user_info, secrets) {
 get_github <- function(path){
   parts <- strsplit(path, "/")[[1]]
   if (length(parts) < 2) {
-    cat("{\"get_github_raw\":\"github path should contain at least two parts\"}")
+    cat("{\"get_github_raw\":\"github path should contain at least two parts\"}\n")
     stop()
   }
   
@@ -61,15 +61,15 @@ get_github <- function(path){
     write_disk(tar_name)
   )
   if (status_code(response1) == "200") {
-    cat("{\"get_github\":\"Successful\"}")
+    cat("{\"get_github\":\"Successful\"}\n")
     lists <- untar(tar_name, list=TRUE)
     untar(tar_name, file=paste0(lists[1],path))
     unlink(tar_name, force=TRUE)
   } else if (status_code(response1)=="401"){
-    cat("{\"get_github\":\"Bad credentials - check github token\"}")
+    cat("{\"get_github\":\"Bad credentials - check github token\"}\n")
     stop()
   } else {
-    cat("{\"get_github\":\"Not found - check github repo: ",username,"/",repo,"\"}")
+    cat("{\"get_github\":\"Not found - check github repo: ",username,"/",repo,"\"}\n")
     stop()
   }
 }
@@ -85,7 +85,7 @@ get_github_raw <- function(token=NULL, path=NULL) {
   
   parts <- strsplit(github_repo, "/")[[1]]
   if (length(parts) < 3) {
-    cat("{\"get_github_raw\":\"github path should contain at least three parts\"}")
+    cat("{\"get_github_raw\":\"github path should contain at least three parts\"}\n")
     stop()
   }
   username <- parts[1]
@@ -119,7 +119,7 @@ get_github_raw <- function(token=NULL, path=NULL) {
   }
   # Check if the request was successful
   if (status_code(response1) == "200") {
-    cat("{\"get_github_raw\":\"Successful\"}")
+    cat("{\"get_github_raw\":\"Successful\"}\n")
     # Parse the response content
     content <- content(response1, "parsed")
     
@@ -131,10 +131,10 @@ get_github_raw <- function(token=NULL, path=NULL) {
     #return (faasr)
     
   } else if (status_code(response1)=="401"){
-    cat("{\"get_github_raw\":\"Bad credentials - check github token\"}")
+    cat("{\"get_github_raw\":\"Bad credentials - check github token\"}\n")
     stop()
   } else {
-    cat("{\"get_github_raw\":\"Not found - check github repo: ",username,"/",repo,"\"}")
+    cat("{\"get_github_raw\":\"Not found - check github repo: ",username,"/",repo,"\"}\n")
     stop()
   }
 }

--- a/base/faasr_start_invoke_github-actions.R
+++ b/base/faasr_start_invoke_github-actions.R
@@ -138,7 +138,10 @@ token <- secrets[["PAYLOAD_GITHUB_TOKEN"]]
 
 # Replace secrets to faasr
 #cat("exec.R: will update user payload\n")
-faasr_source <- replace_values(.faasr, secrets)
+faasr_source <- .faasr
+faasr_source$ComputeServers <- replace_values(faasr_source$ComputeServers, secrets$computeservers)
+faasr_source$DataStores <- replace_values(faasr_source$DataStores, secrets$datastores)
+
 
 # back to json formate
 .faasr <- toJSON(faasr_source, auto_unbox = TRUE)

--- a/base/faasr_start_invoke_github-actions.R
+++ b/base/faasr_start_invoke_github-actions.R
@@ -95,6 +95,7 @@ get_github_raw <- function(token=NULL, path=NULL) {
   pat <- token
   url <- paste0("https://api.github.com/repos/", username, "/", repo, "/contents/", path)
 
+  # Send the POST request
   if (is.null(pat)){
     response1 <- GET(
       url = url,
@@ -138,21 +139,16 @@ get_github_raw <- function(token=NULL, path=NULL) {
   }
 }
 
-
 secrets <- fromJSON(Sys.getenv("SECRET_PAYLOAD"))
 token <- secrets[["PAYLOAD_GITHUB_TOKEN"]]
+.faasr <- fromJSON(get_github_raw(token=token))
 
-
-.faasr <- fromJSON(get_github_raw(token))
 
 .faasr$InvocationID <- Sys.getenv("INPUT_ID")
 .faasr$FunctionInvoke <- Sys.getenv("INPUT_INVOKENAME")
 .faasr$FaaSrLog <- Sys.getenv("INPUT_FAASRLOG")
-#cat("exec.R: faasr-invocationID is: ", faasr$InvocationID, "\n")
-#cat("exec.R: faasr-FunctionInvoke is: ", faasr$FunctionInvoke, "\n")
 
 # Replace secrets to faasr
-#cat("exec.R: will update user payload\n")
 faasr_source <- .faasr
 faasr_source <- replace_values(faasr, secrets)
 

--- a/base/faasr_start_invoke_github-actions.R
+++ b/base/faasr_start_invoke_github-actions.R
@@ -37,7 +37,8 @@ replace_values <- function(user_info, secrets) {
 get_github <- function(token, path){
   parts <- strsplit(path, "/")[[1]]
   if (length(parts) < 2) {
-    stop("PAYLOAD_REPO should contains at least three parts.")
+    cat("{\"get_github_raw\":\"github path should contains at least two parts\"}")
+    stop()
   }
   
   username <- parts[1]
@@ -62,14 +63,17 @@ get_github <- function(token, path){
     write_disk(tar_name)
   )
   if (status_code(response1) == "200") {
-      cat("exec.R: success get payload from github repo\n")
-      lists <- untar(tar_name, list=TRUE)
-      untar(tar_name, file=paste0(lists[1],path))
-      unlink(tar_name, force=TRUE)
-    }else{
-      print(paste("Error:", http_status(response1)$message))
-      stop()
-    }
+    cat("{\"get_github\":\"Successful\"}")
+    lists <- untar(tar_name, list=TRUE)
+    untar(tar_name, file=paste0(lists[1],path))
+    unlink(tar_name, force=TRUE)
+  } else if (status_code(response1)=="401"){
+    cat("{\"get_github\":\"Bad credentials - check github token\"}")
+    stop()
+  } else {
+    cat("{\"get_github\":\"Not found - check github repo: ",username,"/",repo,"\"}")
+    stop()
+  }
 }
 
 
@@ -83,7 +87,8 @@ get_github_raw <- function(token, path=NULL) {
   
   parts <- strsplit(github_repo, "/")[[1]]
   if (length(parts) < 3) {
-    stop("PAYLOAD_REPO should contains at least three parts.")
+    cat("{\"get_github_raw\":\"github path should contains at least three parts\"}")
+    stop()
   }
   username <- parts[1]
   repo <- parts[2]
@@ -105,7 +110,7 @@ get_github_raw <- function(token, path=NULL) {
 
   # Check if the request was successful
   if (status_code(response1) == "200") {
-    cat("{\"faasr_start_invoke_github-actions\":\"success get payload from github repo\"}\n")
+    cat("{\"get_github_raw\":\"Successful\"}")
     # Parse the response content
     content <- content(response1, "parsed")
     
@@ -116,8 +121,11 @@ get_github_raw <- function(token, path=NULL) {
     #faasr <- fromJSON(file_content)
     #return (faasr)
     
+  } else if (status_code(response1)=="401"){
+    cat("{\"get_github_raw\":\"Bad credentials - check github token\"}")
+    stop()
   } else {
-    print(paste("Error:", http_status(response1)$message))
+    cat("{\"get_github_raw\":\"Not found - check github repo: ",username,"/",repo,"\"}")
     stop()
   }
 }

--- a/base/faasr_start_invoke_github-actions.R
+++ b/base/faasr_start_invoke_github-actions.R
@@ -73,9 +73,6 @@ get_github <- function(token, path){
 }
 
 
-
-
-
 get_github_raw <- function(token, path=NULL) {
   # GitHub username and repo
   if (is.null(path)){
@@ -130,7 +127,7 @@ secrets <- fromJSON(Sys.getenv("SECRET_PAYLOAD"))
 token <- secrets[["PAYLOAD_GITHUB_TOKEN"]]
 
 
-.faasr <- fromJSON(get_github_raw(secrets))
+.faasr <- fromJSON(get_github_raw(token))
 
 .faasr$InvocationID <- Sys.getenv("INPUT_ID")
 .faasr$FunctionInvoke <- Sys.getenv("INPUT_INVOKENAME")
@@ -149,8 +146,13 @@ funcname <- faasr_source$FunctionInvoke
 gits <- faasr_source$FunctionGitRepo[[funcname]]
 if (length(gits)==0){NULL} else{
   for (path in gits){
-    get_github(token, path)
-  }
+    file_name <- basename(path)
+    if (grepl("\\.", file_name)){
+      content <- get_github_raw(token, path)
+      eval(parse(text=content))
+    }else{
+      get_github(token, path)
+    }
 }
 	
 packages <- faasr_source$FunctionCRANPackage[[[funcname]]

--- a/base/faasr_start_invoke_github-actions.R
+++ b/base/faasr_start_invoke_github-actions.R
@@ -90,7 +90,7 @@ get_github_raw <- function(token, path=NULL) {
   repo <- parts[2]
   
   path <- paste(parts[3: length(parts)], collapse = "/")
-  pat <- secrets[["PAYLOAD_GITHUB_TOKEN"]]
+  pat <- token
   url <- paste0("https://api.github.com/repos/", username, "/", repo, "/contents/", path)
 
   # Send the POST request

--- a/base/faasr_start_invoke_github-actions.R
+++ b/base/faasr_start_invoke_github-actions.R
@@ -9,7 +9,6 @@
 
 library("httr")
 library("jsonlite")
-library("githubinstall")
 library("FaaSr")
 
 # Recursive function to replace values
@@ -150,13 +149,19 @@ funcname <- faasr_source$FunctionInvoke
 gits <- faasr_source$FunctionGitRepo[[funcname]]
 if (length(gits)==0){NULL} else{
   for (path in gits){
-    file_name <- basename(path)
-    if (endsWith(file_name, ".R") || endsWith(file_name, ".r")){
-      content <- get_github_raw(token, path)
-      eval(parse(text=content))
-    }else{
-      get_github(token, path)
+    if (endsWith(path, ".git")) {
+      command <- paste("git clone --depth=1",file)
+      system(command, ignore.stderr=TRUE)
+    } else {
+      file_name <- basename(path)
+      if (endsWith(file_name, ".R") || endsWith(file_name, ".r")){
+        content <- get_github_raw(token, path)
+        eval(parse(text=content))
+      }else{
+        get_github(token, path)
+      }
     }
+  }
 }
 	
 packages <- faasr_source$FunctionCRANPackage[[[funcname]]
@@ -169,8 +174,7 @@ for (package in packages){
 ghpackages <- faasr_source$FunctionGitHubPackage[[funcname]]
 if (length(ghpackages)==0){NULL} else{
 for (ghpackage in ghpackages){
-	#githubinstall(ghpackage)
-	devtools::install_github(ghpackage)
+	devtools::install_github(ghpackage, force=TRUE)
 	}
 }
 

--- a/base/faasr_start_invoke_github-actions.R
+++ b/base/faasr_start_invoke_github-actions.R
@@ -99,7 +99,7 @@ faasr_source <- replace_values(.faasr, secrets)
 .faasr <- toJSON(faasr_source, auto_unbox = TRUE)
 actionname <- faasr_source$FunctionList[[faasr_source$FunctionInvoke]]$Actionname
 
-gits <- faasr_source$FunctionGitRepo[[actionname]]
+gits <- faasr_source$FunctionInvoke
 if (length(gits)==0){NULL} else{
 for (file in gits){
 	command <- paste("git clone --depth=1",file)
@@ -107,14 +107,14 @@ for (file in gits){
 	}
 }
 
-packages <- faasr_source$FunctionCRANPackage[[actionname]]
+packages <- faasr_source$FunctionInvoke
 if (length(packages)==0){NULL} else{
 for (package in packages){
 	install.packages(package)
 	}
 }
 
-ghpackages <- faasr_source$FunctionGitHubPackage[[actionname]]
+ghpackages <- faasr_source$FunctionInvoke
 if (length(ghpackages)==0){NULL} else{
 for (ghpackage in ghpackages){
 	githubinstall("ghpackage")

--- a/base/faasr_start_invoke_github-actions.R
+++ b/base/faasr_start_invoke_github-actions.R
@@ -37,7 +37,7 @@ replace_values <- function(user_info, secrets) {
 get_github <- function(token, path){
   parts <- strsplit(path, "/")[[1]]
   if (length(parts) < 2) {
-    cat("{\"get_github_raw\":\"github path should contains at least two parts\"}")
+    cat("{\"get_github_raw\":\"github path should contain at least two parts\"}")
     stop()
   }
   
@@ -87,7 +87,7 @@ get_github_raw <- function(token, path=NULL) {
   
   parts <- strsplit(github_repo, "/")[[1]]
   if (length(parts) < 3) {
-    cat("{\"get_github_raw\":\"github path should contains at least three parts\"}")
+    cat("{\"get_github_raw\":\"github path should contain at least three parts\"}")
     stop()
   }
   username <- parts[1]

--- a/base/faasr_start_invoke_github-actions.R
+++ b/base/faasr_start_invoke_github-actions.R
@@ -15,7 +15,7 @@ library("FaaSr")
 replace_values <- function(user_info, secrets) {
   
   for (name in names(user_info)) {
-    if (name == "FunctionList") {
+    if (name != "ComputeServers" || name != "DataStores") {
       next
     }
     # If the value is a list, call this function recursively
@@ -146,9 +146,7 @@ token <- secrets[["PAYLOAD_GITHUB_TOKEN"]]
 # Replace secrets to faasr
 #cat("exec.R: will update user payload\n")
 faasr_source <- .faasr
-faasr_source$ComputeServers <- replace_values(faasr_source$ComputeServers, secrets$computeservers)
-faasr_source$DataStores <- replace_values(faasr_source$DataStores, secrets$datastores)
-
+faasr_source <- replace_values(faasr, secrets)
 
 # back to json formate
 .faasr <- toJSON(faasr_source, auto_unbox = TRUE)

--- a/base/faasr_start_invoke_github-actions.R
+++ b/base/faasr_start_invoke_github-actions.R
@@ -83,20 +83,20 @@ get_payload <- function(secrets) {
 secrets <- fromJSON(Sys.getenv("SECRET_PAYLOAD"))
 
 
-faasr <- get_payload(secrets)
+.faasr <- get_payload(secrets)
 
-faasr$InvocationID <- Sys.getenv("INPUT_ID")
-faasr$FunctionInvoke <- Sys.getenv("INPUT_INVOKENAME")
-faasr$FaaSrLog <- Sys.getenv("INPUT_FAASRLOG")
+.faasr$InvocationID <- Sys.getenv("INPUT_ID")
+.faasr$FunctionInvoke <- Sys.getenv("INPUT_INVOKENAME")
+.faasr$FaaSrLog <- Sys.getenv("INPUT_FAASRLOG")
 #cat("exec.R: faasr-invocationID is: ", faasr$InvocationID, "\n")
 #cat("exec.R: faasr-FunctionInvoke is: ", faasr$FunctionInvoke, "\n")
 
 # Replace secrets to faasr
 #cat("exec.R: will update user payload\n")
-faasr_source <- replace_values(faasr, secrets)
+faasr_source <- replace_values(.faasr, secrets)
 
 # back to json formate
-faasr <- toJSON(faasr_source, auto_unbox = TRUE)
+.faasr <- toJSON(faasr_source, auto_unbox = TRUE)
 actionname <- faasr_source$FunctionList[[faasr_source$FunctionInvoke]]$Actionname
 
 gits <- faasr_source$FunctionGitRepo[[actionname]]
@@ -128,5 +128,5 @@ for (rfile in r_files){
 	}
 }
 
-faasr_start(faasr)
+faasr_start(.faasr)
 

--- a/base/faasr_start_invoke_github-actions.R
+++ b/base/faasr_start_invoke_github-actions.R
@@ -15,7 +15,7 @@ library("FaaSr")
 replace_values <- function(user_info, secrets) {
   
   for (name in names(user_info)) {
-    if (name != "ComputeServers" && name != "DataStores") {
+    if (name == "FunctionList") {
       next
     }
     # If the value is a list, call this function recursively

--- a/base/faasr_start_invoke_github-actions.R
+++ b/base/faasr_start_invoke_github-actions.R
@@ -66,6 +66,7 @@ get_github <- function(token, path){
       cat("exec.R: success get payload from github repo\n")
       lists <- untar(tar_name, list=TRUE)
       untar(tar_name, file=paste0(lists[1],path))
+      unlink(tar_name, force=TRUE)
     }else{
       print(paste("Error:", http_status(response1)$message))
       stop()

--- a/base/faasr_start_invoke_openwhisk_aws-lambda.R
+++ b/base/faasr_start_invoke_openwhisk_aws-lambda.R
@@ -143,13 +143,6 @@ get_github_raw <- function(token=NULL, path=NULL) {
 faasr_source <- fromJSON(.faasr)
 funcname <- faasr_source$FunctionInvoke
 
-for (name in names(faasr_source$ComputeServers)){
-  if (faasr_source$ComputeServers[[name]]$FaaSType=="GitHubActions"){
-    token <- faasr_source$ComputeServers[[name]]$Token
-    break
-  }
-}
-
 gits <- faasr_source$FunctionGitRepo[[funcname]]
 if (length(gits)==0){NULL} else{
   for (path in gits){

--- a/base/faasr_start_invoke_openwhisk_aws-lambda.R
+++ b/base/faasr_start_invoke_openwhisk_aws-lambda.R
@@ -14,7 +14,7 @@ library("FaaSr")
 replace_values <- function(user_info, secrets) {
   
   for (name in names(user_info)) {
-    if (name != "ComputeServers" && name != "DataStores") {
+    if (name == "FunctionList") {
       next
     }
     # If the value is a list, call this function recursively

--- a/base/faasr_start_invoke_openwhisk_aws-lambda.R
+++ b/base/faasr_start_invoke_openwhisk_aws-lambda.R
@@ -14,7 +14,7 @@ library("FaaSr")
 replace_values <- function(user_info, secrets) {
   
   for (name in names(user_info)) {
-    if (name == "FunctionList") {
+    if (name != "ComputeServers" && name != "DataStores") {
       next
     }
     # If the value is a list, call this function recursively
@@ -33,7 +33,7 @@ replace_values <- function(user_info, secrets) {
 
 # REST API get faasr payload json file from repo
 
-get_github <- function(token, path){
+get_github <- function(path){
   parts <- strsplit(path, "/")[[1]]
   if (length(parts) < 2) {
     cat("{\"get_github_raw\":\"github path should contain at least two parts\"}")
@@ -48,14 +48,12 @@ get_github <- function(token, path){
   } else {
     path <- NULL
   }
-  pat <- token
   url <- paste0("https://api.github.com/repos/", repo, "/tarball")
   tar_name <- paste0(reponame,".tar.gz")
   response1 <- GET(
     url = url,
     encode = "json",
     add_headers(
-      Authorization = paste("token", pat),
       Accept = "application/vnd.github.v3+json",
       "X-GitHub-Api-Version" = "2022-11-28"
     ),
@@ -76,7 +74,7 @@ get_github <- function(token, path){
 }
 
 
-get_github_raw <- function(token, path=NULL) {
+get_github_raw <- function(token=NULL, path=NULL) {
   # GitHub username and repo
   if (is.null(path)){
     github_repo <- Sys.getenv("PAYLOAD_REPO")
@@ -97,15 +95,27 @@ get_github_raw <- function(token, path=NULL) {
   url <- paste0("https://api.github.com/repos/", username, "/", repo, "/contents/", path)
 
   # Send the POST request
-  response1 <- GET(
-    url = url,
-    encode = "json",
-    add_headers(
-      Authorization = paste("token", pat),
-      Accept = "application/vnd.github.v3+json",
-      "X-GitHub-Api-Version" = "2022-11-28"
+  if (is.null(pat)){
+    response1 <- GET(
+      url = url,
+      encode = "json",
+      add_headers(
+        Accept = "application/vnd.github.v3+json",
+        "X-GitHub-Api-Version" = "2022-11-28"
+      )
     )
-  )
+  } else {
+  # Send the POST request
+    response1 <- GET(
+      url = url,
+      encode = "json",
+      add_headers(
+        Authorization = paste("token", pat),
+        Accept = "application/vnd.github.v3+json",
+        "X-GitHub-Api-Version" = "2022-11-28"
+      )
+    )
+  }
 
   # Check if the request was successful
   if (status_code(response1) == "200") {
@@ -132,7 +142,7 @@ get_github_raw <- function(token, path=NULL) {
 .faasr <- commandArgs(TRUE)
 faasr_source <- fromJSON(.faasr)
 funcname <- faasr_source$FunctionInvoke
-token <- NULL
+
 for (name in names(faasr_source$ComputeServers)){
   if (faasr_source$ComputeServers[[name]]$FaaSType=="GitHubActions"){
     token <- faasr_source$ComputeServers[[name]]$Token
@@ -142,44 +152,21 @@ for (name in names(faasr_source$ComputeServers)){
 
 gits <- faasr_source$FunctionGitRepo[[funcname]]
 if (length(gits)==0){NULL} else{
-  if (!is.null(token)){
-      for (path in gits){
-        if (endsWith(path, ".git")) {
-          command <- paste("git clone --depth=1",path)
-          check <- system(command, ignore.stderr=TRUE)
-	  if (check!=0){
-	  cat(paste0("{\"faasr_start_invoke_openwhisk_aws-lambda\":\"no repo found, check repository: ",path,"\"}\n"))
-	  stop()
-	  }
-        } else {
-          file_name <- basename(path)
-          if (endsWith(file_name, ".R") || endsWith(file_name, ".r")){
-            content <- get_github_raw(token, path)
-            eval(parse(text=content))
-          }else{
-            get_github(token, path)
-          }
-        }
+  for (path in gits){
+    if (endsWith(path, ".git") && startsWith(path, "http")) {
+      command <- paste("git clone --depth=1",path)
+      check <- system(command, ignore.stderr=TRUE)
+      if (check!=0){
+	cat(paste0("{\"faasr_start_invoke_github-actions\":\"no repo found, check repository url: ",repo,"\"}\n"))
+	stop()
       }
-  } else {
-    for (path in gits){
-      if (endsWith(path, ".git")){
-	command <- paste("git clone --depth=1", path)
-	check <- system(command, ignore.stderr=TRUE)
-	if (check!=0){
-	  cat(paste0("{\"faasr_start_invoke_openwhisk_aws-lambda\":\"no repo found, check repository: ",path,"\"}\n"))
-	  stop()
-	}
-      } else {
-	parts <- strsplit(path, "/")[[1]]
-	repo <- paste0(parts[1],"/",parts[2])
-	cat(paste0("{\"faasr_start_invoke_openwhisk_aws-lambda\":\"no token found, try cloning a git from \"https://github.com/",repo,".git\"}\n"))
-	command <- paste0("git clone --depth=1 https://github.com/",repo,".git")
-	check <- system(command, ignore.stderr=TRUE)
-	if (check!=0){
-	  cat(paste0("{\"faasr_start_invoke_openwhisk_aws-lambda\":\"no repo found, check repository: ",repo,"\"}\n"))
-	  stop()
-	}
+    } else {
+      file_name <- basename(path)
+      if (endsWith(file_name, ".R") || endsWith(file_name, ".r")){
+        content <- get_github_raw(path=path)
+        eval(parse(text=content))
+      }else{
+        get_github(path)
       }
     }
   }

--- a/base/faasr_start_invoke_openwhisk_aws-lambda.R
+++ b/base/faasr_start_invoke_openwhisk_aws-lambda.R
@@ -36,7 +36,7 @@ replace_values <- function(user_info, secrets) {
 get_github <- function(token, path){
   parts <- strsplit(path, "/")[[1]]
   if (length(parts) < 2) {
-    cat("{\"get_github_raw\":\"github path should contains at least two parts\"}")
+    cat("{\"get_github_raw\":\"github path should contain at least two parts\"}")
     stop()
   }
   
@@ -86,7 +86,7 @@ get_github_raw <- function(token, path=NULL) {
   
   parts <- strsplit(github_repo, "/")[[1]]
   if (length(parts) < 3) {
-    cat("{\"get_github_raw\":\"github path should contains at least three parts\"}")
+    cat("{\"get_github_raw\":\"github path should contain at least three parts\"}")
     stop()
   }
   username <- parts[1]

--- a/base/faasr_start_invoke_openwhisk_aws-lambda.R
+++ b/base/faasr_start_invoke_openwhisk_aws-lambda.R
@@ -143,7 +143,7 @@ if (length(gits)==0){NULL} else{
   }
 }
 	
-packages <- faasr_source$FunctionCRANPackage[[[funcname]]
+packages <- faasr_source$FunctionCRANPackage[[funcname]]
 if (length(packages)==0){NULL} else{
 for (package in packages){
 	install.packages(package)

--- a/base/faasr_start_invoke_openwhisk_aws-lambda.R
+++ b/base/faasr_start_invoke_openwhisk_aws-lambda.R
@@ -36,7 +36,8 @@ replace_values <- function(user_info, secrets) {
 get_github <- function(token, path){
   parts <- strsplit(path, "/")[[1]]
   if (length(parts) < 2) {
-    stop("PAYLOAD_REPO should contains at least three parts.")
+    cat("{\"get_github_raw\":\"github path should contains at least two parts\"}")
+    stop()
   }
   
   username <- parts[1]
@@ -61,14 +62,16 @@ get_github <- function(token, path){
     write_disk(tar_name)
   )
   if (status_code(response1) == "200") {
-      cat("exec.R: success get payload from github repo\n")
-      lists <- untar(tar_name, list=TRUE)
-      untar(tar_name, file=paste0(lists[1],path))
-      unlink(tar_name, force=TRUE)
-    }else{
-      print(paste("Error:", http_status(response1)$message))
-      stop()
-    }
+    cat("{\"get_github\":\"Successful\"}")
+    lists <- untar(tar_name, list=TRUE)
+    untar(tar_name, file=paste0(lists[1],path))
+    unlink(tar_name, force=TRUE)
+  } else if (status_code(response1)=="401"){
+    cat("{\"get_github\":\"Bad credentials - check github token\"}")
+    stop()
+  } else {
+    cat("{\"get_github\":\"Not found - check github repo: ",username,"/",repo,"\"}")
+    stop()
 }
 
 
@@ -82,7 +85,8 @@ get_github_raw <- function(token, path=NULL) {
   
   parts <- strsplit(github_repo, "/")[[1]]
   if (length(parts) < 3) {
-    stop("PAYLOAD_REPO should contains at least three parts.")
+    cat("{\"get_github_raw\":\"github path should contains at least three parts\"}")
+    stop()
   }
   username <- parts[1]
   repo <- parts[2]
@@ -104,7 +108,7 @@ get_github_raw <- function(token, path=NULL) {
 
   # Check if the request was successful
   if (status_code(response1) == "200") {
-    cat("exec.R: success get payload from github repo\n")
+    cat("{\"get_github_raw\":\"Successful\"}")
     # Parse the response content
     content <- content(response1, "parsed")
     
@@ -115,10 +119,12 @@ get_github_raw <- function(token, path=NULL) {
     #faasr <- fromJSON(file_content)
     #return (faasr)
     
-  } else {
-    print(paste("Error:", http_status(response1)$message))
+  } else if (status_code(response1)=="401"){
+    cat("{\"get_github_raw\":\"Bad credentials - check github token\"}")
     stop()
-  }
+  } else {
+    cat("{\"get_github_raw\":\"Not found - check github repo: ",username,"/",repo,"\"}")
+    stop()
 }
 
 .faasr <- commandArgs(TRUE)
@@ -133,7 +139,7 @@ if (length(gits)==0){NULL} else{
           command <- paste("git clone --depth=1",path)
           check <- system(command, ignore.stderr=TRUE)
 	  if (check!=0){
-	  cat(paste0("{\"faasr_start_invoke_github-actions\":\"no repo found, check repository: ",repo,"\"}\n"))
+	  cat(paste0("{\"faasr_start_invoke_openwhisk_aws-lambda\":\"no repo found, check repository: ",path,"\"}\n"))
 	  stop()
 	  }
         } else {
@@ -152,17 +158,17 @@ if (length(gits)==0){NULL} else{
 	command <- paste("git clone --depth=1", path)
 	check <- system(command, ignore.stderr=TRUE)
 	if (check!=0){
-	  cat(paste0("{\"faasr_start_invoke_github-actions\":\"no repo found, check repository: ",repo,"\"}\n"))
+	  cat(paste0("{\"faasr_start_invoke_openwhisk_aws-lambda\":\"no repo found, check repository: ",path,"\"}\n"))
 	  stop()
 	}
       } else {
 	parts <- strsplit(path, "/")[[1]]
 	repo <- paste0(parts[1],"/",parts[2])
-	cat(paste0("{\"faasr_start_invoke_github-actions\":\"no token found, try cloning a git from \"https://github.com/",repo,".git\"}\n"))
+	cat(paste0("{\"faasr_start_invoke_openwhisk_aws-lambda\":\"no token found, try cloning a git from \"https://github.com/",repo,".git\"}\n"))
 	command <- paste0("git clone --depth=1 https://github.com/",repo,".git")
 	check <- system(command, ignore.stderr=TRUE)
 	if (check!=0){
-	  cat(paste0("{\"faasr_start_invoke_github-actions\":\"no repo found, check repository: ",repo,"\"}\n"))
+	  cat(paste0("{\"faasr_start_invoke_openwhisk_aws-lambda\":\"no repo found, check repository: ",repo,"\"}\n"))
 	  stop()
 	}
       }

--- a/base/faasr_start_invoke_openwhisk_aws-lambda.R
+++ b/base/faasr_start_invoke_openwhisk_aws-lambda.R
@@ -8,32 +8,152 @@
 #' @param JSON payload is passed as an input when the docker container starts.
 
 library("jsonlite")
-library("githubinstall")
+library("httr")
 library("FaaSr")
 
-faasr <- commandArgs(TRUE)
-faasr_source <- fromJSON(faasr)
-actionname <- faasr_source$FunctionList[[faasr_source$FunctionInvoke]]$Actionname
+.faasr <- commandArgs(TRUE)
+faasr_source <- fromJSON(.faasr)
+funcname <- faasr_source$FunctionInvoke
 
-gits <- faasr_source$FunctionGitRepo[[actionname]]
+replace_values <- function(user_info, secrets) {
+  
+  for (name in names(user_info)) {
+    if (name == "FunctionList") {
+      next
+    }
+    # If the value is a list, call this function recursively
+    if (is.list(user_info[[name]])) {
+      user_info[[name]] <- replace_values(user_info[[name]], secrets)
+    } else {
+      # If the value exists in the secrets, replace it
+      if (user_info[[name]] %in% names(secrets)) {
+        user_info[[name]] <- secrets[[user_info[[name]]]]
+      }
+    }
+  }
+  
+  return(user_info)
+}
+
+# REST API get faasr payload json file from repo
+
+get_github <- function(token, path){
+  parts <- strsplit(path, "/")[[1]]
+  if (length(parts) < 2) {
+    stop("PAYLOAD_REPO should contains at least three parts.")
+  }
+  
+  username <- parts[1]
+  reponame <- parts[2]
+  repo <- paste0(username,"/",reponame)
+  if (length(parts) > 2) {
+    path <- paste(parts[3: length(parts)], collapse = "/")
+  } else {
+    path <- NULL
+  }
+  pat <- token
+  url <- paste0("https://api.github.com/repos/", repo, "/tarball")
+  tar_name <- paste0(reponame,".tar.gz")
+  response1 <- GET(
+    url = url,
+    encode = "json",
+    add_headers(
+      Authorization = paste("token", pat),
+      Accept = "application/vnd.github.v3+json",
+      "X-GitHub-Api-Version" = "2022-11-28"
+    ),
+    write_disk(tar_name)
+  )
+  if (status_code(response1) == "200") {
+      cat("exec.R: success get payload from github repo\n")
+      lists <- untar(tar_name, list=TRUE)
+      untar(tar_name, file=paste0(lists[1],path))
+      unlink(tar_name, force=TRUE)
+    }else{
+      print(paste("Error:", http_status(response1)$message))
+      stop()
+    }
+}
+
+
+get_github_raw <- function(token, path=NULL) {
+  # GitHub username and repo
+  if (is.null(path)){
+    github_repo <- Sys.getenv("PAYLOAD_REPO")
+  } else{
+    github_repo <- path
+  }
+  
+  parts <- strsplit(github_repo, "/")[[1]]
+  if (length(parts) < 3) {
+    stop("PAYLOAD_REPO should contains at least three parts.")
+  }
+  username <- parts[1]
+  repo <- parts[2]
+  
+  path <- paste(parts[3: length(parts)], collapse = "/")
+  pat <- token
+  url <- paste0("https://api.github.com/repos/", username, "/", repo, "/contents/", path)
+
+  # Send the POST request
+  response1 <- GET(
+    url = url,
+    encode = "json",
+    add_headers(
+      Authorization = paste("token", pat),
+      Accept = "application/vnd.github.v3+json",
+      "X-GitHub-Api-Version" = "2022-11-28"
+    )
+  )
+
+  # Check if the request was successful
+  if (status_code(response1) == "200") {
+    cat("exec.R: success get payload from github repo\n")
+    # Parse the response content
+    content <- content(response1, "parsed")
+    
+    # The content of the file is in the 'content' field and is base64 encoded
+    file_content <- rawToChar(base64enc::base64decode(content$content))
+    return(file_content)
+
+    #faasr <- fromJSON(file_content)
+    #return (faasr)
+    
+  } else {
+    print(paste("Error:", http_status(response1)$message))
+    stop()
+  }
+}
+
+gits <- faasr_source$FunctionGitRepo[[funcname]]
 if (length(gits)==0){NULL} else{
-for (file in gits){
-	command <- paste("git clone --depth=1",file)
-	system(command, ignore.stderr=TRUE)
-	}
+  for (path in gits){
+    if (endsWith(path, ".git")) {
+      command <- paste("git clone --depth=1",file)
+      system(command, ignore.stderr=TRUE)
+    } else {
+      file_name <- basename(path)
+      if (endsWith(file_name, ".R") || endsWith(file_name, ".r")){
+        content <- get_github_raw(token, path)
+        eval(parse(text=content))
+      }else{
+        get_github(token, path)
+      }
+    }
+  }
 }
 	
-packages <- faasr_source$FunctionCRANPackage[[actionname]]
+packages <- faasr_source$FunctionCRANPackage[[[funcname]]
 if (length(packages)==0){NULL} else{
 for (package in packages){
 	install.packages(package)
 	}
 }
 
-ghpackages <- faasr_source$FunctionGitHubPackage[[actionname]]
+ghpackages <- faasr_source$FunctionGitHubPackage[[funcname]]
 if (length(ghpackages)==0){NULL} else{
 for (ghpackage in ghpackages){
-	githubinstall("ghpackage")
+	devtools::install_github(ghpackage, force=TRUE)
 	}
 }
 
@@ -44,6 +164,4 @@ for (rfile in r_files){
 	}
 }
 
-
-faasr_start(faasr)
-
+faasr_start(.faasr)

--- a/base/faasr_start_invoke_openwhisk_aws-lambda.R
+++ b/base/faasr_start_invoke_openwhisk_aws-lambda.R
@@ -36,7 +36,7 @@ replace_values <- function(user_info, secrets) {
 get_github <- function(path){
   parts <- strsplit(path, "/")[[1]]
   if (length(parts) < 2) {
-    cat("{\"get_github_raw\":\"github path should contain at least two parts\"}")
+    cat("{\"get_github_raw\":\"github path should contain at least two parts\"}\n")
     stop()
   }
   
@@ -60,15 +60,15 @@ get_github <- function(path){
     write_disk(tar_name)
   )
   if (status_code(response1) == "200") {
-    cat("{\"get_github\":\"Successful\"}")
+    cat("{\"get_github\":\"Successful\"}\n")
     lists <- untar(tar_name, list=TRUE)
     untar(tar_name, file=paste0(lists[1],path))
     unlink(tar_name, force=TRUE)
   } else if (status_code(response1)=="401"){
-    cat("{\"get_github\":\"Bad credentials - check github token\"}")
+    cat("{\"get_github\":\"Bad credentials - check github token\"}\n")
     stop()
   } else {
-    cat("{\"get_github\":\"Not found - check github repo: ",username,"/",repo,"\"}")
+    cat("{\"get_github\":\"Not found - check github repo: ",username,"/",repo,"\"}\n")
     stop()
   }
 }
@@ -84,7 +84,7 @@ get_github_raw <- function(token=NULL, path=NULL) {
   
   parts <- strsplit(github_repo, "/")[[1]]
   if (length(parts) < 3) {
-    cat("{\"get_github_raw\":\"github path should contain at least three parts\"}")
+    cat("{\"get_github_raw\":\"github path should contain at least three parts\"}\n")
     stop()
   }
   username <- parts[1]
@@ -119,7 +119,7 @@ get_github_raw <- function(token=NULL, path=NULL) {
 
   # Check if the request was successful
   if (status_code(response1) == "200") {
-    cat("{\"get_github_raw\":\"Successful\"}")
+    cat("{\"get_github_raw\":\"Successful\"}\n")
     # Parse the response content
     content <- content(response1, "parsed")
     
@@ -131,10 +131,10 @@ get_github_raw <- function(token=NULL, path=NULL) {
     #return (faasr)
     
   } else if (status_code(response1)=="401"){
-    cat("{\"get_github_raw\":\"Bad credentials - check github token\"}")
+    cat("{\"get_github_raw\":\"Bad credentials - check github token\"}\n")
     stop()
   } else {
-    cat("{\"get_github_raw\":\"Not found - check github repo: ",username,"/",repo,"\"}")
+    cat("{\"get_github_raw\":\"Not found - check github repo: ",username,"/",repo,"\"}\n")
     stop()
   }
 }

--- a/base/faasr_start_invoke_openwhisk_aws-lambda.R
+++ b/base/faasr_start_invoke_openwhisk_aws-lambda.R
@@ -132,6 +132,13 @@ get_github_raw <- function(token, path=NULL) {
 .faasr <- commandArgs(TRUE)
 faasr_source <- fromJSON(.faasr)
 funcname <- faasr_source$FunctionInvoke
+token <- NULL
+for (name in names(faasr_source$ComputeServers)){
+  if (faasr_source$ComputeServers[[name]]$FaaSType=="GitHubActions"){
+    token <- faasr_source$ComputeServers[[name]]$Token
+    break
+  }
+}
 
 gits <- faasr_source$FunctionGitRepo[[funcname]]
 if (length(gits)==0){NULL} else{

--- a/base/faasr_start_invoke_openwhisk_aws-lambda.R
+++ b/base/faasr_start_invoke_openwhisk_aws-lambda.R
@@ -129,7 +129,7 @@ gits <- faasr_source$FunctionGitRepo[[funcname]]
 if (length(gits)==0){NULL} else{
   for (path in gits){
     if (endsWith(path, ".git")) {
-      command <- paste("git clone --depth=1",file)
+      command <- paste("git clone --depth=1",path)
       system(command, ignore.stderr=TRUE)
     } else {
       file_name <- basename(path)

--- a/base/faasr_start_invoke_openwhisk_aws-lambda.R
+++ b/base/faasr_start_invoke_openwhisk_aws-lambda.R
@@ -72,6 +72,7 @@ get_github <- function(token, path){
   } else {
     cat("{\"get_github\":\"Not found - check github repo: ",username,"/",repo,"\"}")
     stop()
+  }
 }
 
 
@@ -125,6 +126,7 @@ get_github_raw <- function(token, path=NULL) {
   } else {
     cat("{\"get_github_raw\":\"Not found - check github repo: ",username,"/",repo,"\"}")
     stop()
+  }
 }
 
 .faasr <- commandArgs(TRUE)


### PR DESCRIPTION
[support many options for GitHub repository]
1. implement get_github and get_github_raw to bring files in the repository as a form of “tar.gz” or “raw”. Now users can use not only “.git url” but also “username/reponame”, “username/reponame/path” (for directory), “username/reponame/path/file” (for specific file) into the “FunctionGitRepo”
2. Users will use function name as keys for “FunctionGitRepo”, “FunctionCRANPackage” and “FunctionGitHubPackage”.
3. Add more error handling messages

[hide “faasr” from users]
1. Change “faasr” to “.faasr”

[Githubinstall errors/R_packages.R]
1. Replace “githubinstall” to “install_github”
2. Remove "install_version(githubinstall)" as we don't use it anymore