### PR TITLE
[workflow for github container registry]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,8 @@ env:
   TAG_SUFFIX: dev
   AWS_REGION: us-east-1
 
+permissions: write-all
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -21,6 +23,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to the Github Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -48,15 +56,15 @@ jobs:
         run: |
           docker tag openwhisk-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} ${{ secrets.DOCKERHUB_USERNAME }}/openwhisk-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }}
           docker push ${{ secrets.DOCKERHUB_USERNAME }}/openwhisk-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }}
-      - name: Build github-actions-tidyverse Docker image
+      - name: Build github-actions-tidyverse Container registry image
         run: |
           cd github-actions
           mv Dockerfile-tidyverse Dockerfile
-          docker build -t github-actions-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} --build-arg FAASR_TAG=${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} .
-      - name: Push github-actions-tidyverse Docker image
+          docker build -t ghcr.io/${{ github.repository_owner }}/github-actions-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} --build-arg FAASR_TAG=${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} .
+      - name: Push github-actions-tidyverse Container registry image
         run: |
-          docker tag github-actions-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} ${{ secrets.DOCKERHUB_USERNAME }}/github-actions-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }}
-          docker push ${{ secrets.DOCKERHUB_USERNAME }}/github-actions-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }}
+          docker tag ghcr.io/${{ github.repository_owner }}/github-actions-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} ghcr.io/${{ github.actor }}/github-actions-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }}
+          docker push ghcr.io/${{ github.repository_owner }}/github-actions-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }}
       - name: Build aws-lambda-tidyverse Container image
         run: |
           cd aws-lambda

--- a/.github/workflows/tag_with_latest.yml
+++ b/.github/workflows/tag_with_latest.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 env:
   TIDYVERSE_VERSION: 4.3.1
-  FAASR_VERSION: 1.0.3.0
+  FAASR_VERSION: 1.0.4.0
   TAG_SUFFIX: dev
   AWS_REGION: us-east-1
 

--- a/.github/workflows/tag_with_latest.yml
+++ b/.github/workflows/tag_with_latest.yml
@@ -4,8 +4,10 @@ on: workflow_dispatch
 
 env:
   TIDYVERSE_VERSION: 4.3.1
-  FAASR_VERSION: 1.0.3.0
+  FAASR_VERSION: 1.0.4.0
   TAG_SUFFIX: dev
+
+permissions: write-all
 
 jobs:
   tag-latest:
@@ -16,6 +18,21 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to the Github Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2  
       - name: Pull openwhisk-tidyverse Docker image
         run: |
           docker pull ${{ secrets.DOCKERHUB_USERNAME }}/openwhisk-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} 
@@ -23,19 +40,19 @@ jobs:
         run: |
           docker tag ${{ secrets.DOCKERHUB_USERNAME }}/openwhisk-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} ${{ secrets.DOCKERHUB_USERNAME }}/openwhisk-tidyverse:latest
           docker push ${{ secrets.DOCKERHUB_USERNAME }}/openwhisk-tidyverse:latest
-      - name: Pull github-actions-tidyverse Docker image
+      - name: Pull github-actions-tidyverse Github Container registry image
         run: |
-          docker pull ${{ secrets.DOCKERHUB_USERNAME }}/github-actions-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} 
-      - name: Tag and push openwhisk-tidyverse Docker image
+          docker pull ghcr.io/${{ github.repository_owner }}/github-actions-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} 
+      - name: Tag and push github-actions-tidyverse Github Container registry image
         run: |
-          docker tag ${{ secrets.DOCKERHUB_USERNAME }}/github-actions-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} ${{ secrets.DOCKERHUB_USERNAME }}/github-actions-tidyverse:latest
-          docker push ${{ secrets.DOCKERHUB_USERNAME }}/github-actions-tidyverse:latest
-      - name: Pull aws-lambda-tidyverse Docker image
+          docker tag ghcr.io/${{ github.repository_owner }}/github-actions-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} ghcr.io/${{ github.repository_owner }}/github-actions-tidyverse:latest
+          docker push ghcr.io/${{ github.repository_owner }}/github-actions-tidyverse:latest
+      - name: Pull aws-lambda-tidyverse AWS ECR image
         run: |
-          docker pull ${{ secrets.DOCKERHUB_USERNAME }}/aws-lambda-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} 
-      - name: Tag and push aws-lambda-tidyverse Docker image
+          docker pull ${{ steps.login-ecr.outputs.registry }}/aws-lambda-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} 
+      - name: Tag and push aws-lambda-tidyverse AWS ECR image
         run: |
-          docker tag ${{ secrets.DOCKERHUB_USERNAME }}/aws-lambda-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} ${{ secrets.DOCKERHUB_USERNAME }}/aws-lambda-tidyverse:latest
-          docker push ${{ secrets.DOCKERHUB_USERNAME }}/aws-lambda-tidyverse:latest
+          docker tag ${{ steps.login-ecr.outputs.registry }}/aws-lambda-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} ${{ steps.login-ecr.outputs.registry }}/aws-lambda-tidyverse:latest
+          docker push ${{ steps.login-ecr.outputs.registry }}/aws-lambda-tidyverse:latest
 
           

--- a/.github/workflows/tag_with_latest.yml
+++ b/.github/workflows/tag_with_latest.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 env:
   TIDYVERSE_VERSION: 4.3.1
-  FAASR_VERSION: 1.0.4.0
+  FAASR_VERSION: 1.0.3.0
   TAG_SUFFIX: dev
   AWS_REGION: us-east-1
 

--- a/.github/workflows/tag_with_latest.yml
+++ b/.github/workflows/tag_with_latest.yml
@@ -6,6 +6,7 @@ env:
   TIDYVERSE_VERSION: 4.3.1
   FAASR_VERSION: 1.0.4.0
   TAG_SUFFIX: dev
+  AWS_REGION: us-east-1
 
 permissions: write-all
 


### PR DESCRIPTION
1. main.yml
- Github actions images will be deployed on the package of the FaaSr github container registry instead of Docker hub
2. tag_with_latest.yml
- Github actions & AWS images will be tagged as latest with each URI on the github container registry / aws ECR instead of Docker hub.