### PR TITLE
[container R script sequence / Divide base image from the others]

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -1,0 +1,31 @@
+name: Build and push Base image
+
+on: workflow_dispatch
+
+env:
+  TIDYVERSE_VERSION: 4.3.1
+  FAASR_VERSION: 1.0.9.0
+  TAG_SUFFIX: dev
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: new-test
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build base-tidyverse Docker image
+        run: |
+          cd base
+          mv Dockerfile-tidyverse Dockerfile
+          docker build -t base-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} --build-arg TIDYVERSE_TAG=${{ env.TIDYVERSE_VERSION }} .
+      - name: Push base-tidyverse Docker image
+        run: |
+          docker tag base-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} ${{ secrets.DOCKERHUB_USERNAME }}/base-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }}
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/base-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,10 @@
-name: Build and push Docker image
+name: Build and push Each FaaS platform image
 
 on: workflow_dispatch
 
 env:
-  TIDYVERSE_VERSION: 4.3.1
-  FAASR_VERSION: 1.0.8.0
-  FAASR_TAG: 1.0.8.0
+  FAASR_VERSION: 1.0.9.0
+  FAASR_TAG: 1.0.9.0
   FAASR_INSTALL_REPO: FaaSr/FaaSr-package
   GHCR_IO_REPO: faasr
   TAG_SUFFIX: dev
@@ -18,7 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          ref: new-test
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -39,38 +40,20 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
-      - name: Build base-tidyverse Docker image
-        run: |
-          cd base
-          mv Dockerfile-tidyverse Dockerfile
-          docker build -t base-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} --build-arg TIDYVERSE_TAG=${{ env.TIDYVERSE_VERSION }} --build-arg FAASR_TAG=${{ env.FAASR_TAG }} --build-arg FAASR_INSTALL_REPO=${{ env.FAASR_INSTALL_REPO }} .
-      - name: Push base-tidyverse Docker image
-        run: |
-          docker tag base-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} ${{ secrets.DOCKERHUB_USERNAME }}/base-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }}
-          docker push ${{ secrets.DOCKERHUB_USERNAME }}/base-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }}
       - name: Build openwhisk-tidyverse Docker image
         run: |
           cd openwhisk
           mv Dockerfile-tidyverse Dockerfile
-          docker build -t openwhisk-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} --build-arg FAASR_TAG=${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} .
+          docker build -t openwhisk-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} --build-arg FAASR_VERSION=${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} --build-arg FAASR_TAG=${{ env.FAASR_TAG }} --build-arg FAASR_INSTALL_REPO=${{ env.FAASR_INSTALL_REPO }} .
       - name: Push openwhisk-tidyverse Docker image
         run: |
           docker tag openwhisk-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} ${{ secrets.DOCKERHUB_USERNAME }}/openwhisk-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }}
           docker push ${{ secrets.DOCKERHUB_USERNAME }}/openwhisk-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }}
-#      - name: Build github-actions-tidyverse Docker image
-#        run: |
-#          cd github-actions
-#          mv Dockerfile-tidyverse Dockerfile
-#          docker build -t github-actions-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} --build-arg FAASR_TAG=${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} .
-#      - name: Push github-actions-tidyverse Docker image
-#        run: |
-#          docker tag github-actions-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} ${{ secrets.DOCKERHUB_USERNAME }}/github-actions-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }}
-#          docker push ${{ secrets.DOCKERHUB_USERNAME }}/github-actions-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }}
       - name: Build github-actions-tidyverse Container registry image
         run: |
           cd github-actions
           mv Dockerfile-tidyverse Dockerfile
-          docker build -t ghcr.io/${{ env.GHCR_IO_REPO }}/github-actions-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} --build-arg FAASR_TAG=${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} .
+          docker build -t ghcr.io/${{ env.GHCR_IO_REPO }}/github-actions-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} --build-arg FAASR_VERSION=${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} --build-arg FAASR_TAG=${{ env.FAASR_TAG }} --build-arg FAASR_INSTALL_REPO=${{ env.FAASR_INSTALL_REPO }} .
       - name: Push github-actions-tidyverse Container registry image
         run: |
           docker tag ghcr.io/${{ env.GHCR_IO_REPO }}/github-actions-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} ghcr.io/${{ github.actor }}/github-actions-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }}
@@ -79,7 +62,7 @@ jobs:
         run: |
           cd aws-lambda
           mv Dockerfile-tidyverse Dockerfile
-          docker build -t ${{ steps.login-ecr.outputs.registry }}/aws-lambda-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} --build-arg FAASR_TAG=${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} .
+          docker build -t ${{ steps.login-ecr.outputs.registry }}/aws-lambda-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} --build-arg FAASR_VERSION=${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }} --build-arg FAASR_TAG=${{ env.FAASR_TAG }} --build-arg FAASR_INSTALL_REPO=${{ env.FAASR_INSTALL_REPO }} .
       - name: Push aws-lambda-tidyverse Container image
         run: |
           docker push ${{ steps.login-ecr.outputs.registry }}/aws-lambda-tidyverse:${{ env.FAASR_VERSION }}-${{ env.TAG_SUFFIX }}

--- a/.github/workflows/tag_with_latest.yml
+++ b/.github/workflows/tag_with_latest.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 env:
   TIDYVERSE_VERSION: 4.3.1
-  FAASR_VERSION: 1.0.8.0
+  FAASR_VERSION: 1.0.9.0
   TAG_SUFFIX: dev
   GHCR_IO_REPO: faasr
   AWS_REGION: us-east-1

--- a/aws-lambda/Dockerfile-tidyverse
+++ b/aws-lambda/Dockerfile-tidyverse
@@ -1,5 +1,12 @@
+ARG FAASR_VERSION
+FROM faasr/base-tidyverse:$FAASR_VERSION
+
+# Get arguments
 ARG FAASR_TAG
-FROM faasr/base-tidyverse:$FAASR_TAG
+ARG FAASR_INSTALL_REPO
+
+# Install FaaSr
+RUN Rscript -e "args <- commandArgs(trailingOnly=TRUE); library(devtools); install_github(paste0(args[1],'@',args[2]),force=TRUE)" $FAASR_INSTALL_REPO $FAASR_TAG
 
 RUN chmod -R 755 /action
 

--- a/base/faasr_start_invoke_helper.R
+++ b/base/faasr_start_invoke_helper.R
@@ -199,3 +199,19 @@ faasr_source_r_files <- function(){
   }
 }
 
+faasr_dependency_install <- function(faasr_source, funcname, new_lib=NULL){
+  # get files from Git repository
+  gits <- faasr_source$FunctionGitRepo[[funcname]]
+  faasr_install_git_repo(gits)
+
+  # install CRAN packages
+  packages <- faasr_source$FunctionCRANPackage[[funcname]]
+  faasr_install_cran(packages, lib_path=new_lib)
+
+  # install Git packages
+  ghpackages <- faasr_source$FunctionGitHubPackage[[funcname]]
+  faasr_install_git_package(ghpackages, lib_path=new_lib)
+
+  # source R files
+  faasr_source_r_files()
+}

--- a/base/faasr_start_invoke_openwhisk.R
+++ b/base/faasr_start_invoke_openwhisk.R
@@ -14,24 +14,24 @@ source("faasr_start_invoke_helper.R")
 
 # get arguments from stdin
 .faasr <- commandArgs(TRUE)
-faasr_source <- fromJSON(.faasr)
-funcname <- faasr_source$FunctionList[[faasr_source$FunctionInvoke]]$FunctionName
-
-# get files from Git repository
-gits <- faasr_source$FunctionGitRepo[[funcname]]
-faasr_install_git_repo(gits)
-
-# install CRAN packages
-packages <- faasr_source$FunctionCRANPackage[[funcname]]
-faasr_install_cran(packages)
-
-# install Git packages
-ghpackages <- faasr_source$FunctionGitHubPackage[[funcname]]
-faasr_install_git_package(ghpackages)
-
-# source R files
-faasr_source_r_files()
 
 # start FaaSr
-FaaSr::faasr_start(.faasr)
+.faasr <- FaaSr::faasr_start(.faasr)
 
+# Download the dependencies
+funcname <- .faasr$FunctionList[[.faasr$FunctionInvoke]]$FunctionName
+faasr_dependency_install(.faasr, funcname)
+
+# Execute User function
+FaaSr::faasr_run_user_function(.faasr)
+
+# Trigger the next functions
+FaaSr::faasr_trigger(.faasr)
+
+# Leave logs
+msg_1 <- paste0('{\"faasr\":\"Finished execution of User Function ',.faasr$FunctionInvoke,'\"}', "\n")
+cat(msg_1)
+result <- faasr_log(msg_1)
+msg_2 <- paste0('{\"faasr\":\"With Action Invocation ID is ',.faasr$InvocationID,'\"}', "\n")
+cat(msg_2)
+result <- faasr_log(msg_2)

--- a/github-actions/Dockerfile-tidyverse
+++ b/github-actions/Dockerfile-tidyverse
@@ -1,5 +1,12 @@
+ARG FAASR_VERSION
+FROM faasr/base-tidyverse:$FAASR_VERSION
+
+# Get arguments
 ARG FAASR_TAG
-FROM faasr/base-tidyverse:$FAASR_TAG
+ARG FAASR_INSTALL_REPO
+
+# Install FaaSr
+RUN Rscript -e "args <- commandArgs(trailingOnly=TRUE); library(devtools); install_github(paste0(args[1],'@',args[2]),force=TRUE)" $FAASR_INSTALL_REPO $FAASR_TAG
 
 WORKDIR /action
 

--- a/openwhisk/Dockerfile-tidyverse
+++ b/openwhisk/Dockerfile-tidyverse
@@ -1,4 +1,11 @@
+ARG FAASR_VERSION
+FROM faasr/base-tidyverse:$FAASR_VERSION
+
+# Get arguments
 ARG FAASR_TAG
-FROM faasr/base-tidyverse:$FAASR_TAG
+ARG FAASR_INSTALL_REPO
+
+# Install FaaSr
+RUN Rscript -e "args <- commandArgs(trailingOnly=TRUE); library(devtools); install_github(paste0(args[1],'@',args[2]),force=TRUE)" $FAASR_INSTALL_REPO $FAASR_TAG
 
 CMD ["/bin/bash","-c","cd actionProxy && python3 actionproxy.py"]


### PR DESCRIPTION
1. Container R script sequence changed
- Now, sequence is "faasr_start" -> "dependence install" -> "user_function_run" -> "faasr_trigger" 
- This is to avoid aborted functions downloading packages.
2. Divide base image from the others
- FaaSr packages will be install on each FaaS platform's image
- Workflow for base image will be separately managed.