### PR TITLE
Use Faasr base image version 1.1.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 env:
   # The base version (Rocker+dependences, FaaS-agnostic) to build from
-  FAASR_BASE_VERSION: 1.1.1
+  FAASR_BASE_VERSION: 1.1.2
   # The GitHub FaaSr tag to install from
   FAASR_TAG: 1.1.2
   # The GitHub FaaSr repo to install from


### PR DESCRIPTION
The main.yml action incorrectly uses faasr/base-tidyverse version 1.1.1. This pull request updates it to 1.1.2