### PR TITLE
[Issue #89] Support invocation of multiple concurrent actions in GitHub Actions

### DIFF
--- a/base/faasr_start_invoke_github-actions.R
+++ b/base/faasr_start_invoke_github-actions.R
@@ -15,10 +15,11 @@ source("faasr_start_invoke_helper.R")
 # get arguments from environments
 secrets <- fromJSON(Sys.getenv("SECRET_PAYLOAD"))
 token <- Sys.getenv("GITHUB_PAT")
-.faasr <- fromJSON(faasr_get_github_raw(token=token))
-.faasr$InvocationID <- Sys.getenv("INPUT_ID")
-.faasr$FunctionInvoke <- Sys.getenv("INPUT_INVOKENAME")
-.faasr$FaaSrLog <- Sys.getenv("INPUT_FAASRLOG")
+.faasr <- fromJSON(Sys.getenv("PAYLOAD"))
+#.faasr <- fromJSON(faasr_get_github_raw(token=token))
+#.faasr$InvocationID <- Sys.getenv("INPUT_ID")
+#.faasr$FunctionInvoke <- Sys.getenv("INPUT_INVOKENAME")
+#.faasr$FaaSrLog <- Sys.getenv("INPUT_FAASRLOG")
 
 # Replace secrets to faasr
 .faasr <- FaaSr::faasr_replace_values(.faasr, secrets)

--- a/base/faasr_start_invoke_github-actions.R
+++ b/base/faasr_start_invoke_github-actions.R
@@ -16,10 +16,6 @@ source("faasr_start_invoke_helper.R")
 secrets <- fromJSON(Sys.getenv("SECRET_PAYLOAD"))
 token <- Sys.getenv("GITHUB_PAT")
 .faasr <- fromJSON(Sys.getenv("PAYLOAD"))
-#.faasr <- fromJSON(faasr_get_github_raw(token=token))
-#.faasr$InvocationID <- Sys.getenv("INPUT_ID")
-#.faasr$FunctionInvoke <- Sys.getenv("INPUT_INVOKENAME")
-#.faasr$FaaSrLog <- Sys.getenv("INPUT_FAASRLOG")
 
 # Replace secrets to faasr
 .faasr <- FaaSr::faasr_replace_values(.faasr, secrets)

--- a/faas_specific/aws-lambda.Dockerfile
+++ b/faas_specific/aws-lambda.Dockerfile
@@ -8,9 +8,6 @@ ARG FAASR_VERSION
 # FAASR_INSTALL_REPO is tha name of the user's GitHub repository to install FaaSr from e.g. janedoe/FaaSr-Package-dev
 ARG FAASR_INSTALL_REPO
 
-RUN rm /action/FaaSr.schema.json
-ADD https://raw.githubusercontent.com/spark0510/FaaSr-package/branch74-issue89/schema/FaaSr.schema.json /action/
-
 # Install FaaSr from specified repo and tag
 RUN Rscript -e "args <- commandArgs(trailingOnly=TRUE); library(devtools); install_github(paste0(args[1],'@',args[2]),force=TRUE)" $FAASR_INSTALL_REPO $FAASR_VERSION
 

--- a/faas_specific/aws-lambda.Dockerfile
+++ b/faas_specific/aws-lambda.Dockerfile
@@ -8,6 +8,8 @@ ARG FAASR_VERSION
 # FAASR_INSTALL_REPO is tha name of the user's GitHub repository to install FaaSr from e.g. janedoe/FaaSr-Package-dev
 ARG FAASR_INSTALL_REPO
 
+RUN rm /action/FaaSr.schema.json
+ADD https://raw.githubusercontent.com/spark0510/FaaSr-package/branch74-issue89/schema/FaaSr.schema.json /action/
 
 # Install FaaSr from specified repo and tag
 RUN Rscript -e "args <- commandArgs(trailingOnly=TRUE); library(devtools); install_github(paste0(args[1],'@',args[2]),force=TRUE)" $FAASR_INSTALL_REPO $FAASR_VERSION

--- a/faas_specific/github-actions.Dockerfile
+++ b/faas_specific/github-actions.Dockerfile
@@ -8,6 +8,11 @@ ARG FAASR_VERSION
 # FAASR_INSTALL_REPO is tha name of the user's GitHub repository to install FaaSr from e.g. janedoe/FaaSr-Package-dev
 ARG FAASR_INSTALL_REPO
 
+RUN rm /action/FaaSr.schema.json
+ADD https://raw.githubusercontent.com/spark0510/FaaSr-package/branch74-issue89/schema/FaaSr.schema.json /action/
+
+RUN rm /action/faasr_start_invoke_github-actions.R
+ADD https://raw.githubusercontent.com/spark0510/FaaSr-Docker/refs/heads/github/base/faasr_start_invoke_github-actions.R /action/
 
 # Install FaaSr from specified repo and tag
 RUN Rscript -e "args <- commandArgs(trailingOnly=TRUE); library(devtools); install_github(paste0(args[1],'@',args[2]),force=TRUE)" $FAASR_INSTALL_REPO $FAASR_VERSION

--- a/faas_specific/github-actions.Dockerfile
+++ b/faas_specific/github-actions.Dockerfile
@@ -12,7 +12,8 @@ RUN rm /action/FaaSr.schema.json
 ADD https://raw.githubusercontent.com/spark0510/FaaSr-package/branch74-issue89/schema/FaaSr.schema.json /action/
 
 RUN rm /action/faasr_start_invoke_github-actions.R
-ADD https://raw.githubusercontent.com/spark0510/FaaSr-Docker/refs/heads/github/base/faasr_start_invoke_github-actions.R /action/
+ADD https://raw.githubusercontent.com/spark0510/FaaSr-Docker/refs/heads/main/base/faasr_start_invoke_github-actions.R /action/
+
 
 # Install FaaSr from specified repo and tag
 RUN Rscript -e "args <- commandArgs(trailingOnly=TRUE); library(devtools); install_github(paste0(args[1],'@',args[2]),force=TRUE)" $FAASR_INSTALL_REPO $FAASR_VERSION

--- a/faas_specific/github-actions.Dockerfile
+++ b/faas_specific/github-actions.Dockerfile
@@ -8,13 +8,6 @@ ARG FAASR_VERSION
 # FAASR_INSTALL_REPO is tha name of the user's GitHub repository to install FaaSr from e.g. janedoe/FaaSr-Package-dev
 ARG FAASR_INSTALL_REPO
 
-RUN rm /action/FaaSr.schema.json
-ADD https://raw.githubusercontent.com/spark0510/FaaSr-package/branch74-issue89/schema/FaaSr.schema.json /action/
-
-RUN rm /action/faasr_start_invoke_github-actions.R
-ADD https://raw.githubusercontent.com/spark0510/FaaSr-Docker/refs/heads/main/base/faasr_start_invoke_github-actions.R /action/
-
-
 # Install FaaSr from specified repo and tag
 RUN Rscript -e "args <- commandArgs(trailingOnly=TRUE); library(devtools); install_github(paste0(args[1],'@',args[2]),force=TRUE)" $FAASR_INSTALL_REPO $FAASR_VERSION
 

--- a/faas_specific/openwhisk.Dockerfile
+++ b/faas_specific/openwhisk.Dockerfile
@@ -8,9 +8,6 @@ ARG FAASR_VERSION
 # FAASR_INSTALL_REPO is tha name of the user's GitHub repository to install FaaSr from e.g. janedoe/FaaSr-Package-dev
 ARG FAASR_INSTALL_REPO
 
-RUN rm /action/FaaSr.schema.json
-ADD https://raw.githubusercontent.com/spark0510/FaaSr-package/branch74-issue89/schema/FaaSr.schema.json /action/
-
 # Install FaaSr from specified repo and tag
 RUN Rscript -e "args <- commandArgs(trailingOnly=TRUE); library(devtools); install_github(paste0(args[1],'@',args[2]),force=TRUE)" $FAASR_INSTALL_REPO $FAASR_VERSION
 

--- a/faas_specific/openwhisk.Dockerfile
+++ b/faas_specific/openwhisk.Dockerfile
@@ -8,6 +8,8 @@ ARG FAASR_VERSION
 # FAASR_INSTALL_REPO is tha name of the user's GitHub repository to install FaaSr from e.g. janedoe/FaaSr-Package-dev
 ARG FAASR_INSTALL_REPO
 
+RUN rm /action/FaaSr.schema.json
+ADD https://raw.githubusercontent.com/spark0510/FaaSr-package/branch74-issue89/schema/FaaSr.schema.json /action/
 
 # Install FaaSr from specified repo and tag
 RUN Rscript -e "args <- commandArgs(trailingOnly=TRUE); library(devtools); install_github(paste0(args[1],'@',args[2]),force=TRUE)" $FAASR_INSTALL_REPO $FAASR_VERSION


### PR DESCRIPTION
1. GitHub Actions now uses payload not from the repository, but from the R console.
- new system environment "PAYLOAD" is added
- other system environments are deleted (no more used)