### PR TITLE
Update Docker Container Scripts to Handle Function Results from faasr_run_user_function

### DIFF
--- a/.github/workflows/build_github-actions.yml
+++ b/.github/workflows/build_github-actions.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.event.inputs.GHCR_IO_REPO }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_TOKEN }}
       - name: Build github-actions Container registry image
         run: |
           cd faas_specific

--- a/.github/workflows/build_github-actions.yml
+++ b/.github/workflows/build_github-actions.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.event.inputs.GHCR_IO_REPO }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build github-actions Container registry image
         run: |
           cd faas_specific

--- a/base/faasr_start_invoke_aws-lambda.R
+++ b/base/faasr_start_invoke_aws-lambda.R
@@ -30,7 +30,7 @@ funcname <- .faasr$FunctionList[[.faasr$FunctionInvoke]]$FunctionName
 faasr_dependency_install(.faasr, funcname, new_lib=new_lib)
 
 # Execute User function
-FaaSr::faasr_run_user_function(.faasr)
+.faasr <- FaaSr::faasr_run_user_function(.faasr)
 
 # Trigger the next functions
 FaaSr::faasr_trigger(.faasr)

--- a/base/faasr_start_invoke_github-actions.R
+++ b/base/faasr_start_invoke_github-actions.R
@@ -40,7 +40,7 @@ funcname <- .faasr$FunctionList[[.faasr$FunctionInvoke]]$FunctionName
 faasr_dependency_install(.faasr, funcname)
 
 # Execute User function
-FaaSr::faasr_run_user_function(.faasr)
+.faasr <- FaaSr::faasr_run_user_function(.faasr)
 
 # Trigger the next functions
 FaaSr::faasr_trigger(.faasr)

--- a/base/faasr_start_invoke_openwhisk.R
+++ b/base/faasr_start_invoke_openwhisk.R
@@ -26,7 +26,7 @@ funcname <- .faasr$FunctionList[[.faasr$FunctionInvoke]]$FunctionName
 faasr_dependency_install(.faasr, funcname)
 
 # Execute User function
-FaaSr::faasr_run_user_function(.faasr)
+.faasr <- FaaSr::faasr_run_user_function(.faasr)
 
 # Trigger the next functions
 FaaSr::faasr_trigger(.faasr)


### PR DESCRIPTION
# Update Docker Container Scripts to Handle Function Results from faasr_run_user_function

## Overview
This PR updates the Docker container startup scripts across all FaaS platforms to properly handle the return value from `faasr_run_user_function()`. The function now returns an updated `.faasr` object that includes function execution results needed for conditional workflow execution.

## Changes Made

### Updated Files
- **`base/faasr_start_invoke_aws-lambda.R`**: Updated to capture `.faasr` return value
- **`base/faasr_start_invoke_github-actions.R`**: Updated to capture `.faasr` return value  
- **`base/faasr_start_invoke_openwhisk.R`**: Updated to capture `.faasr` return value

### Specific Change
```r
# Before
FaaSr::faasr_run_user_function(.faasr)

# After  
.faasr <- FaaSr::faasr_run_user_function(.faasr)